### PR TITLE
fix: control JWT of multiple devices

### DIFF
--- a/src/app/_clients/nextAuth.ts
+++ b/src/app/_clients/nextAuth.ts
@@ -8,12 +8,44 @@ export const {
   unstable_update: update,
   handlers,
 } = NextAuth({
+  ...config,
   // https://authjs.dev/getting-started/migrating-to-v5#edge-compatibility
   // @ts-expect-error https://github.com/nextauthjs/next-auth/issues/9493
   adapter: PrismaAdapter(prisma),
   session: {
     strategy: "jwt",
   },
+  callbacks: {
+    ...config.callbacks,
+    jwt: async ({ token, user, trigger }) => {
+      // user exists when only signing in
+      if (user) {
+        token.id = user.id;
+        token.role = user.role;
+      }
+
+      // support for multiple devices
+      const me = await prisma.user.findUnique({
+        where: {
+          id: token.id as string,
+        },
+      });
+
+      // to avoid accessing devices having invalid JWT if user is not found
+      if (trigger !== "signUp" && !user && !me) {
+        throw new Error("User not found");
+      }
+
+      // in favor of the user's latest data and update the token
+      if (me) {
+        token.name = me.name;
+        token.image = me.image;
+        token.email = me.email;
+        token.role = me.role;
+      }
+
+      return token;
+    },
+  },
   ...(process.env.NEXTAUTH_TEST_MODE === "true" ? configForTest : {}),
-  ...config,
 });

--- a/src/app/_clients/nextAuthConfig.ts
+++ b/src/app/_clients/nextAuthConfig.ts
@@ -1,4 +1,6 @@
-// don't import @auth/prisma-adapter here to avoid importing it at Edge
+// don't import prisma or @auth/prisma-adapter here to avoid importing it at Edge
+// [auth][error] JWTSessionError: Read more at https://errors.authjs.dev#jwtsessionerror
+// [auth][cause]: Error: PrismaClient is not configured to run in Edge Runtime (Vercel Edge Functions, Vercel Edge Middleware, Next.js (Pages Router) Edge API Routes, Next.js (App Router) Edge Route Handlers or Next.js Middleware). In order to run Prisma Client on edge runtime, either:
 
 import type { NextAuthConfig, User } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
@@ -24,18 +26,10 @@ export const config = {
     }),
   ],
   callbacks: {
-    redirect: async ({ baseUrl }) => {
+    redirect: ({ url, baseUrl }) => {
       return baseUrl;
     },
-    async jwt({ token, user }) {
-      // user exists when only signing in
-      if (user) {
-        token.id = user.id;
-        token.role = user.role;
-      }
-      return token;
-    },
-    session: async ({ session, token }) => {
+    session: ({ session, token }) => {
       if (session?.user && token) {
         session.user.id = token.id as string;
         session.user.role = token.role as User["role"];

--- a/src/app/globals.d.ts
+++ b/src/app/globals.d.ts
@@ -25,3 +25,9 @@ declare module "next-auth" {
     user: User;
   }
 }
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id: string;
+  }
+}


### PR DESCRIPTION
### 前提
  - roleを使いページのルーティングをmiddlewareで行う
  - prismaは最近になって、middlewareでもadapterを追加することにより動くようになった
    - 今回は、prismaのadapterを利用しない方法を考える
  - jwtを利用したとしても、DBにはuser dataを入れる
  - 個人としては、jwtではなくdatabaseが好き

### 問題
  - middlewareでprisma単体は動かない(他のORMも同様)
    - つまり、next-authではdatabaseではなく、jwtがデファクト
  - middlewareでprisma client, prisma-adapterをimportした時点でエラーが発生する

### JWTを利用したときの問題点
  - マルチデバイスを考えるのがめんどくさい
    - パージの大変さ
      - 例えば、A、B デバイスがあってA側でアカウント削除をした場合にBもinvalidにしないといけない
    - `auth()`が返す値はjwtのuser claimになるため、その情報を正と捉えるのは正しくない
      - 常にすべてのJWTに対してclaim内の情報を更新しないと正しくならない

### 解決策
  - [不採用] `auth()` を実行したあとに idを使い user table へアクセスする
    - 結局、claim内を更新してないので、上記を縛らないとバグを簡単に起こせてしまう
  - [採用] `jwt()`内でuser tableへアクセスし、常に「存在しているか」と「claim内の情報のアップデート」をしuser tableをmasterにする
    - DBへの負荷が増えるものの堅牢